### PR TITLE
Updated org-mode and markdown Syntax to Fix Formatting Issues with org-ruby 

### DIFF
--- a/01-clojure-literate-ants/literate-ants.org
+++ b/01-clojure-literate-ants/literate-ants.org
@@ -4,7 +4,8 @@
 #+LANGUAGE: en
 #+STARTUP: align indent fold nodlcheck hidestars oddeven lognotestate
 #+PROPERTY: tangle literate-ants.clj
-
+#+EXPORT_SELECT_TAGS: export
+#+EXPORT_EXCLUDE_TAGS: noexport
 
 * Introduction
 ** What is this, why is it worthwhile? Quickly please!
@@ -51,9 +52,11 @@
    active format.
 
 ** Why Clojure?
-[[http://clojure.org][Clojure]] is a modern Lisp dialect that runs (primarily) on the [[http://en.wikipedia.org/wiki/Jvm][Java
-Virtual Machine]]. As a language its main paradigm is [[http://en.wikipedia.org/wiki/Functional_programming][functional
-programming]] (vs. the usual [[http://en.wikipedia.org/wiki/Object-oriented_programming][OO]] or [[http://en.wikipedia.org/wiki/Imperative_programming][imperative]] languages of Java, Python,
+[[http://clojure.org][Clojure]] is a modern Lisp dialect that runs (primarily) 
+on the [[http://en.wikipedia.org/wiki/Jvm][Java Virtual Machine]]. 
+As a language its main paradigm is [[http://en.wikipedia.org/wiki/Functional_programming][functional programming]] 
+(vs. the usual [[http://en.wikipedia.org/wiki/Object-oriented_programming][OO]] 
+or [[http://en.wikipedia.org/wiki/Imperative_programming][imperative]] languages of Java, Python,
 Ruby), and it also provides powerful constructs for concurrency such
 as [[http://en.wikipedia.org/wiki/Software_transactional_memory][software transactional memory (STM)]].
 
@@ -70,8 +73,8 @@ So why use or learn Clojure?
 
 ** Why literate ants?
 When Clojure was invented and began picking up interest from
-2007/2008, its creator Rich Hickey would [[http://www.youtube.com/watch?v=dGVqrGmwOAw][highlight Clojure's features
-with a demo program]]: a visual simulation of ants seeking food on a
+2007/2008, its creator Rich Hickey would [[http://www.youtube.com/watch?v=dGVqrGmwOAw][highlight Clojure's features with a demo program]]:
+ a visual simulation of ants seeking food on a
 finite 2-D "world" board. I found the =ants.clj= program fascinating,
 particularly as simulation is a core interest. Historically,
 [[https://en.wikipedia.org/wiki/Object-oriented_programming#History][simulations motivated the object-oriented programming]] paradigm, so
@@ -80,8 +83,8 @@ encapsulation, concurrent state, and modeling changes over time drew
 me in to Clojure.
 
 To build more skill in Clojure, I wanted to fully understand
-=ants.clj=.  I also wanted to try Knuth's [[http://vasc.ri.cmu.edu/old_help/Programming/Literate/literate.html][literate programming
-approach]] (LP), using my favorite tool: [[http://www.gnu.org/software/emacs/][Emacs]] and its peerless
+=ants.clj=.  I also wanted to try Knuth's [[http://vasc.ri.cmu.edu/old_help/Programming/Literate/literate.html][literate programming approach]] (LP),
+ using my favorite tool: [[http://www.gnu.org/software/emacs/][Emacs]] and its peerless
 [[http://orgmode.org][org-mode]]. Thus this =.org= file (and its HTML or PDF version) you're
 now looking at is the literate version of Hickey's =ants.clj= code. I
 took the original program, made minor changes for my comprehension,
@@ -109,8 +112,7 @@ structured literate code file, w/ syntax-highlighted code blocks.
 Before you dive into the actual code, you may want to run the ants
 simulation first - seeing it in action will help with understanding
 the details too.  So tangle this literate file per above instructions,
-so you have the =literate-ants.clj= file, then jump down to [[Running
-the Program]].
+so you have the =literate-ants.clj= file, then jump down to [[Running the Program]].
 
 ** Caveats - this may not be the LP you're looking for
 1. Don't take this file as anything like an ideal literate programming
@@ -140,7 +142,7 @@ be introduced to some of Clojure's powers.
 After the copyright notice, the initial setup code of =ants.clj= is
 easy to understand (for coders at least), even if you've never dealt
 with Lisp before. We see parameters (aka constants and magic numbers)
-being defined for later use using Clojure's =[[http://clojure.org/special_forms#def][def]]= special form: =def=
+being defined for later use using Clojure's [[http://clojure.org/special_forms#def][def]] special form: =def=
 creates a var (a mutable storage location) which connects a symbol to
 a value in the current [[http://clojure.org/namespaces][namespace]].
 
@@ -186,11 +188,11 @@ needs defining:
 #+BEGIN_SRC clojure :exports code :results silent :session s1 
 (defstruct cell :food :pher)  ; May also have :ant and :home values
 #+END_SRC
-First, a call to =[[http://clojuredocs.org/clojure_core/clojure.core/defstruct][defstruct]]= (like a hashmap or dictionary in other
+First, a call to [[http://clojuredocs.org/clojure_core/clojure.core/defstruct][defstruct]] (like a hashmap or dictionary in other
 languages) defines a baseline /cell/. 
 - =defstruct= is like a very lightweight class or
   constructor/template function, and conveniently wraps Clojure's
-  =[[http://clojuredocs.org/clojure_core/clojure.core/create-struct][create-struct]]=.
+  [[http://clojuredocs.org/clojure_core/clojure.core/create-struct][create-struct]].
 - Here, a cell has two keys to start, =:food= and =:pher=, to
   indicate the presence of food and pheromones. A cell may also have
   keys of =:ant= and =:home=, depending on whether an ant and/or the
@@ -200,7 +202,7 @@ Next, the =world= function creates the 2-dimensional "board" of cells
 (here, a square of 80x80 cells), represented as vectors (rows or the
 vertical y-dimension) of a vector (the horizontal x-dimension columns
 in one row):
-#+name sim-world-board-creation
+#+name: sim-world-board-creation
 #+BEGIN_SRC clojure :exports code :results silent :session s1 
 ;; World is a 2d vector of refs to cells
 (def world 
@@ -213,9 +215,9 @@ in one row):
                  (range dim))))
 #+END_SRC
 Reading the above:
-- Start with the innermost =[[http://clojuredocs.org/clojure_core/clojure.core/map][map]]= call, which uses an anonymous
+- Start with the innermost [[http://clojuredocs.org/clojure_core/clojure.core/map][map]] call, which uses an anonymous
   function to create one column of 80 cells, per =(range dim)=. The
-  =[[http://clojuredocs.org/clojure_core/clojure.core/struct][struct]]= returns a new structmap instance using the earlier cell as
+  [[http://clojuredocs.org/clojure_core/clojure.core/struct][struct]] returns a new structmap instance using the earlier cell as
   the basis, initializing the =:food= and =:pher= values to zero.
 - But notice that =struct= is wrapped with a [[http://clojure.org/refs][transactional ref]], and
   here's the first glimpse of Clojure's concurrency powers. With
@@ -305,11 +307,10 @@ To explain the above constructor function for ants, =create-ant=:
 + The [[http://clojuredocs.org/clojure_core/clojure.core/let][let special form]] binds pairs of symbols and expressions in its
   arguments vector, providing local, lexical bindings within the scope
   of the body following.
-+ =sync= will ensure that any mutations of refs using the [[http://clojuredocs.org/clojure_core/clojure.core/alter][alter
-  function]] will be atomic. Previously we had used =ref= around each
++ =sync= will ensure that any mutations of refs using the [[http://clojuredocs.org/clojure_core/clojure.core/alter][alter function]] will be atomic. Previously we had used =ref= around each
   cell, so in the above code where =the-place= is such a ref-wrapped
   cell, =alter= takes =the-place= ref as its first argument, then
-  =[[http://clojuredocs.org/clojure_contrib/clojure.contrib.generic.collection/assoc][assoc]]= as the function to be [[http://clojuredocs.org/clojure_core/clojure.core/apply][apply]]'ed on the-place, tying a new ant
+  [[http://clojuredocs.org/clojure_contrib/clojure.contrib.generic.collection/assoc][assoc]] as the function to be [[http://clojuredocs.org/clojure_core/clojure.core/apply][apply]]'ed on the-place, tying a new ant
   instance to it (remember that as a cell, =the-place= is sure to have
   =:food= and =:pher= key-values already, now we add =:ant=). Like the
   thrush operator earlier, the syntax of =alter= enables convenient
@@ -432,8 +433,7 @@ and [[http://en.wikipedia.org/wiki/Asteroids_(video_game)][Asteroids]]. The func
 these world-behaviors, while the definition of =direction-delta= maps
 a movement in a cardinal direction to the corresponding change in x
 and y. A few comments on each:
-- The =bound= function using the built-in [[http://clojuredocs.org/clojure_core/clojure.core/rem][rem (i.e. remainder)
-  function]] is straightforward. Observe how =bound= is used in
+- The =bound= function using the built-in [[http://clojuredocs.org/clojure_core/clojure.core/rem][rem (i.e. remainder) function]] is straightforward. Observe how =bound= is used in
   delta-location to ensure wrap-around behavior in: 1) cardinal
   directions; 2) the world-board, at its edges given by =dim=.
 - =direction-delta= maps the eight cardinal directions (0 is North) to
@@ -644,10 +644,11 @@ mind its main parts while diving into details:
 Also, consider the context of how =behave= is first used: within the
 main invocation at the end, there's the expression:
 
+#+BEGIN_EXAMPLE clojure
 src_clojure{(dorun (map #(send-off % behave) ants))}
+#+END_EXAMPLE
 
-So the =behave= function is called on every ant agent via the [[http://clojuredocs.org/clojure_core/clojure.core/send-off][send-off
-function]], which is how Clojure dispatches potentially blocking actions
+So the =behave= function is called on every ant agent via the [[http://clojuredocs.org/clojure_core/clojure.core/send-off][send-off function]], which is how Clojure dispatches potentially blocking actions
 to agents. And there certainly are potentially blocking actions when
 using =behave=, since ants may try to move into the same cell, try to
 acquire the same food, etc.
@@ -797,7 +798,7 @@ ants' pheromones diminish and evaporate from the world over time.
 The =evaporate= function fulfills that requirement: 
 + It takes no arguments, it will work over the entire world/board of
   cells, accessed via the tuples of =x= and =y=.
-+ The =[[http://clojuredocs.org/clojure_core/clojure.core/dorun][dorun]]= function takes a lazy collection/sequence (here, that of
++ The [[http://clojuredocs.org/clojure_core/clojure.core/dorun][dorun]] function takes a lazy collection/sequence (here, that of
   the =for= expression) and forces the realization of that collection
   for its side effects, discarding any returned values.
   - It's unlike the similarly-named =doall= where we do care about the
@@ -827,10 +828,9 @@ wrapping calls to Java.
 #+END_SRC
 
 The =import= pulls in classes from [[http://docs.oracle.com/javase/6/docs/api/java/awt/package-summary.html][Java's Abstract Window Toolkit]]
-(AWT) package, and from the Java Swing package. (Aside: curious [[http://stackoverflow.com/questions/727844/javax-vs-java-package][why
-Swing is in the =javax= namespace]]?)  Assuming unfamiliarity with Java
+(AWT) package, and from the Java Swing package. (Aside: curious [[http://stackoverflow.com/questions/727844/javax-vs-java-package][why Swing is in the =javax= namespace]]?)  Assuming unfamiliarity with Java
 Swing, let's describe the classes used:
-+ The =[[http://docs.oracle.com/javase/6/docs/api/java/awt/Color.html][Color]]= class encapsulates a color in the standard RGB color
++ The [[http://docs.oracle.com/javase/6/docs/api/java/awt/Color.html][Color]] class encapsulates a color in the standard RGB color
   space. In the code below, its usage as a constructor for a color
   instance follows several arities:
   - 4 integer arguments: r, g, b, and a for the alpha/transparency (0
@@ -839,9 +839,9 @@ Swing, let's describe the classes used:
   - 1 argument: not a constructor call, but an access of a predefined
     static =Color= field by name, returning the color in the RGB color
     space.
-+ The =[[http://docs.oracle.com/javase/6/docs/api/java/awt/Graphics.html][Graphics]]= class is an abstract base class for all graphics
++ The [[http://docs.oracle.com/javase/6/docs/api/java/awt/Graphics.html][Graphics]] class is an abstract base class for all graphics
   contexts, i.e. a =Graphics= instance holds the current state data
-  needed for rendering it: the =[[http://docs.oracle.com/javase/6/docs/api/java/awt/Component.html][Component]]= object on which to draw,
+  needed for rendering it: the [[http://docs.oracle.com/javase/6/docs/api/java/awt/Component.html][Component]] object on which to draw,
   the current clip, color, and font, etc. Below, we'll see that the
   Clojure functions that take a =Graphics= instance as an argument:
   - =fill-cell=
@@ -849,15 +849,15 @@ Swing, let's describe the classes used:
   - =render-place=
   - =render=
   ...all do some kind of rendering/drawing.
-+ The =[[http://docs.oracle.com/javase/6/docs/api/java/awt/Dimension.html][Dimension]]= class encapsulates the integer width and height of a
++ The [[http://docs.oracle.com/javase/6/docs/api/java/awt/Dimension.html][Dimension]] class encapsulates the integer width and height of a
   component. This class is used just once below, in setting the size
   of the panel of the UI.
-+ =[[http://docs.oracle.com/javase/6/docs/api/java/awt/image/BufferedImage.html][BufferedImage]]= class is needed for raster image data; below, the
++ [[http://docs.oracle.com/javase/6/docs/api/java/awt/image/BufferedImage.html][BufferedImage]] class is needed for raster image data; below, the
   =render= function uses it to paint the background panel.
-+ The =[[http://docs.oracle.com/javase/1.4.2/docs/api/javax/swing/JPanel.html][JPanel]]= class is the generic "lightweight" UI container in Java
++ The [[http://docs.oracle.com/javase/1.4.2/docs/api/javax/swing/JPanel.html][JPanel]] class is the generic "lightweight" UI container in Java
   Swing (seems like the =div= element in HTML).  Below, it's used just
   once for the main display.
-+ The =[[http://docs.oracle.com/javase/1.4.2/docs/api/javax/swing/JFrame.html][JFrame]]= class creates a top-level window (w/ title and border)
++ The [[http://docs.oracle.com/javase/1.4.2/docs/api/javax/swing/JFrame.html][JFrame]] class creates a top-level window (w/ title and border)
   in Swing; it's used just once below for the main ants UI window.
 
 ** Functions to render the board and the ants
@@ -908,7 +908,7 @@ different colors (having food or not):
                 (+ tx (* x scale)) (+ ty (* y scale))))))
 #+END_SRC
 Note the cleverly concise destructuring for the start and end drawing
-coordinates, needed in AWT's =[[http://docs.oracle.com/javase/1.4.2/docs/api/java/awt/Graphics.html#drawLine%28int,%20int,%20int,%20int%29][drawLine]]= method.
+coordinates, needed in AWT's [[http://docs.oracle.com/javase/1.4.2/docs/api/java/awt/Graphics.html#drawLine%28int,%20int,%20int,%20int%29][drawLine]] method.
 
 
 If a cell in the ants' world is not empty, it has one or more of three

--- a/01-clojure-literate-ants/literate-ants.org
+++ b/01-clojure-literate-ants/literate-ants.org
@@ -280,7 +280,7 @@ themselves. As before, we start with =defstruct=, defining an ant as
 having only one required key, its direction. (An ant may temporarily
 have another key, =:food=.)
 
-#+name ants-defined
+#+name: ants-defined
 #+BEGIN_SRC clojure :exports code :results silent :session s1 
 (defstruct ant :dir)  ; Always has dir heading; may also have :food
 
@@ -339,7 +339,7 @@ square will initially contain all the ants - one ant per cell - before
 the simulation runs. We can see these two aspects of the home-square
 in the two =def= calls for =home-offset= and =home-range= below.
 
-#+name home-setup
+#+name: home-setup
 #+BEGIN_SRC clojure :exports code :results silent :session s1 
 (def home-offset (/ dim 4))
 (def home-range (range home-offset (+ nants-sqrt home-offset)))
@@ -397,7 +397,7 @@ atomically and consistently.
 Next, consider facing/orientation and moving to another place in the
 2-D world. Three functions below, followed by explanations:
 
-#+name world-wrapping
+#+name: world-wrapping
 #+BEGIN_SRC clojure :exports code :results silent :session s1 
 (defn bound 
   "Returns given n, wrapped into range 0-b"
@@ -452,7 +452,7 @@ Our ants need two behaviors to get around their world: turning (or
 changing the direction they "face"), and stepping forward.  Let's deal
 with turning first:
 
-#+name ant-agent-turn
+#+name: ant-agent-turn
 #+BEGIN_SRC clojure :exports code :results silent :session s1 
 ;; An ant agent tracks the location of an ant, and controls the
 ;; behavior of the ant at that location.
@@ -476,7 +476,7 @@ with the updated ant.
 
 Now for actual movement to a new place:
 
-#+name ant-agent-move
+#+name: ant-agent-move
 #+BEGIN_SRC clojure :exports code :results silent :session s1 
 (defn move 
   "Moves the ant in the direction it is heading. Must be called in a
@@ -512,7 +512,7 @@ interactions (each having two steps) change the board, and as with the
 =move= function, they need to occur atomically (all-or-nothing) to
 ensure the [[http://www.youtube.com/watch?v=z_KmNZNT5xw][world is in a consistent state]]. 
 
-#+name ant-agent-food
+#+name: ant-agent-food
 #+BEGIN_SRC clojure :exports code :results silent :session s1 
 (defn take-food [loc]
   "Takes one food from current location. Must be called in a
@@ -552,7 +552,7 @@ is based on two states, either:
 So we need functions to express preference of the next location for an
 ant. The functions =rank-by= and =wrand= help with that.
 
-#+name ant-agent-judgment-1
+#+name: ant-agent-judgment-1
 #+BEGIN_SRC clojure :exports code :results silent :session s1 
 (defn rank-by 
   "Returns a map of xs to their 1-based rank when sorted by keyfn."
@@ -598,7 +598,7 @@ Next: The =wrand= function helps with the larger task of randomizing
 which location/cell the ant moves to next in a weighted manner; i.e.
 the "dice" are loaded with =rank-by=, then "rolled" here:
 
-#+name ant-agent-judgment-2
+#+name: ant-agent-judgment-2
 #+BEGIN_SRC clojure :exports code :results silent :session s1 
 (defn wrand 
   "Given a vector of slice sizes, returns the index of a slice given a
@@ -653,7 +653,7 @@ to agents. And there certainly are potentially blocking actions when
 using =behave=, since ants may try to move into the same cell, try to
 acquire the same food, etc.
 
-#+name ant-agent-behave
+#+name: ant-agent-behave
 #+BEGIN_SRC clojure :exports code :results silent :session s1 
 (defn behave 
   "The main function for the ant agent."

--- a/01-clojure-literate-ants/literate-ants.org
+++ b/01-clojure-literate-ants/literate-ants.org
@@ -5,7 +5,7 @@
 #+STARTUP: align indent fold nodlcheck hidestars oddeven lognotestate
 #+PROPERTY: tangle literate-ants.clj
 #+EXPORT_SELECT_TAGS: export
-#+EXPORT_EXCLUDE_TAGS: noexport
+#+EXPORT_EXCLUDE_TAGS: noexport NOEXPORT
 #+OPTIONS: f:t
 
 * Introduction

--- a/01-clojure-literate-ants/literate-ants.org
+++ b/01-clojure-literate-ants/literate-ants.org
@@ -6,6 +6,7 @@
 #+PROPERTY: tangle literate-ants.clj
 #+EXPORT_SELECT_TAGS: export
 #+EXPORT_EXCLUDE_TAGS: noexport
+#+OPTIONS: f:t
 
 * Introduction
 ** What is this, why is it worthwhile? Quickly please!

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ More information
   [Active Documents with Org-Mode](http://www.cs.unm.edu/~eschulte/data/CISE-13-3-SciProg.pdf)
 
 - Pro-tip: when you want to "tangle" or export code blocks from an org
-  file, =CTRL-c-v-t= is the keystroke combo to tangle all blocks.  To
+  file, `CTRL-c-v-t` is the keystroke combo to tangle all blocks.  To
   tangle only ONE block, the current one your cursor is in, just use
-  the Emacs prefix code first: =CTRL-u-c-v-t= For big org files, this
+  the Emacs prefix code first: `CTRL-u-c-v-t` For big org files, this
   saves time, as it's essentially instantaneous to tangle/export one
   block.


### PR DESCRIPTION
While reading through your well written literate programing examples repository, I found a small number of formatting issues that are primarily due to how org-ruby parses org-mode files. At the moment Github and GitLab use org-ruby to render org syntax into markdown which is transformed into HTML. 

Please review my updates and accept my pull request if you think these changes are helpful.

Thank you for writing and sharing your expertise through your literate programing examples repository!

Best wishes!

Melioratus


